### PR TITLE
Automated colormap registration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-matplotlib

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,16 @@
 import setuptools
 
+version = {}
+
+with open("swiftascmaps/version.py", "r") as fh:
+    exec(fh.read(), version)
+
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name="swiftascmaps",
-    version="1.2.0",
+    version=version["__version__"],
     description="Taylor Swift inspired Matplotlib colormaps.",
     url="https://github.com/jborrow/swiftascmaps",
     author="Josh Borrow",

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,11 @@
 import setuptools
-from swiftascmaps import __version__
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name="swiftascmaps",
-    version=__version__,
+    version="1.2.0",
     description="Taylor Swift inspired Matplotlib colormaps.",
     url="https://github.com/jborrow/swiftascmaps",
     author="Josh Borrow",
@@ -21,5 +20,7 @@ setuptools.setup(
         "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
         "Operating System :: OS Independent",
     ],
-    install_requires=[],
+    install_requires=[
+        "matplotlib",
+    ],
 )

--- a/swiftascmaps/make_cmap.py
+++ b/swiftascmaps/make_cmap.py
@@ -53,4 +53,5 @@ def make_custom_cmap(name: str, colors: List) -> Tuple[LinearSegmentedColormap]:
 
     register_cmap(cmap=cmap)
     register_cmap(cmap=cmap_r)
+    
     return cmap, cmap_r

--- a/swiftascmaps/make_cmap.py
+++ b/swiftascmaps/make_cmap.py
@@ -3,6 +3,7 @@ Wrapper function for making color maps from lists
 of colors.
 """
 
+from matplotlib.cm import register_cmap
 from matplotlib.colors import LinearSegmentedColormap
 from typing import Tuple, List
 
@@ -44,10 +45,12 @@ def make_custom_cmap(name: str, colors: List) -> Tuple[LinearSegmentedColormap]:
 
     float_colors = [[x / 255 for x in color] for color in colors]
 
-    cmap = LinearSegmentedColormap.from_list(name, float_colors, N=1024)
+    cmap = LinearSegmentedColormap.from_list(f"swift.{name}", float_colors, N=1024)
 
     cmap_r = LinearSegmentedColormap.from_list(
-        f"{name}_r", list(reversed(float_colors)), N=1024
+        f"swift.{name}_r", list(reversed(float_colors)), N=1024
     )
 
+    register_cmap(cmap=cmap)
+    register_cmap(cmap=cmap_r)
     return cmap, cmap_r


### PR DESCRIPTION
Hi, nice colormaps you have there !

This PR proposes two changes:

- drop the requirements.txt file in favour of setup.py. This makes installation easier since it can be done in one command (`pip install .`) instead of two. I don't think it can be done without duplicating the version tag though.
- use matplotlib.cm.register_cmap and prefix your colormap's name to avoid naming collisions.

This allows for usage as

```python
import numpy as np
import matplotlib.pyplot as plt
import swiftascmaps

data = np.random.randn(100).reshape(10, 10)
plt.imshow(data, cmap="swift.red")
plt.savefig("/tmp/swift_red.png")
```
![swift_red](https://user-images.githubusercontent.com/14075922/114300904-a3f4e280-9ac2-11eb-91fb-07328017a771.png)

Which is similar to how other similar projects in the ecosystem work (for instance cmocean or cmasher).

This PR was initially suggested by @matthewturk
